### PR TITLE
[#433] Show discounted prices in reservation view

### DIFF
--- a/input/assets/css/_store-location.scss
+++ b/input/assets/css/_store-location.scss
@@ -61,6 +61,15 @@
         text-align: right;
       }
 
+      .price-discounted {
+        width: 50%;
+        float: right;
+        font-size: 15px;
+        font-weight: normal;
+        text-align: right;
+        text-decoration: line-through;
+      }
+
       .distance,
       .price {
         margin-bottom: 15px;

--- a/input/templates/partials/catalog/reserve/store-1.json
+++ b/input/templates/partials/catalog/reserve/store-1.json
@@ -11,6 +11,11 @@
           "lng" : 11.47589
         }
     },
-    "price": "50,00 €",
+    "prices": {
+            "value": "50,00 €",
+            "discounted": {
+                "value": "40,00 €"
+            }
+        },
     "availability": "available"
 }

--- a/input/templates/partials/catalog/reserve/store-2.json
+++ b/input/templates/partials/catalog/reserve/store-2.json
@@ -11,6 +11,11 @@
           "lng" : 11.5732545
         }
     },
-    "price": "47,50 €",
+    "prices": {
+            "value": "50,00 €",
+            "discounted": {
+                "value": "40,00 €"
+            }
+        },
     "availability": "notAvailable"
 }

--- a/input/templates/partials/catalog/reserve/store-3.json
+++ b/input/templates/partials/catalog/reserve/store-3.json
@@ -11,6 +11,8 @@
           "lng" : 11.5805786
         }
     },
-    "price": "49,00 €",
+    "prices": {
+            "value": "50,00 €"
+        },
     "availability": "fewItemsLeft"
 }

--- a/input/templates/partials/catalog/reserve/store.hbs
+++ b/input/templates/partials/catalog/reserve/store.hbs
@@ -8,9 +8,19 @@
               </span> km
             </span>
 
-            <b class="price">
-              {{this.price}}
-            </b>
+            {{#if this.prices.discounted}}
+              <span class="price-discounted">
+                {{this.prices.value}}
+              </span>
+
+              <b class="price">
+                {{this.prices.discounted.value}}
+              </b>
+            {{else}}
+              <b class="price">
+                {{this.prices.value}}
+              </b>
+            {{/if}}
 
             <strong class="title">
               {{this.storeInfo.name}}


### PR DESCRIPTION
This is how it looks like now for products that has the discounted prices:

<img width="492" alt="screen shot 2016-10-13 at 18 53 30" src="https://cloud.githubusercontent.com/assets/14938754/19358561/9dcda928-9176-11e6-9232-4eddf52e2c9a.png">

The ones that hasn't remains as before
